### PR TITLE
Feature: read query from file

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Executes queries using the gabi-cli.
 `gabi exec -h`
 
 ```
-Executes a gabi query received from a string as argument or from stdin. When using stdin, press Enter to move to the next line and then CTRL+D to execute the query (or CTRL+C to Cancel)
+Executes a gabi query received from a string as argument, from a file path which gets read or from stdin. When using stdin, press Enter to move to the next line and then CTRL+D to execute the query (or CTRL+C to Cancel)
 
 Usage:
-  gabi execute [string] | stdin [flags]
+  gabi execute [string] | [file_path] | stdin [flags]
 
 Aliases:
   execute, exec

--- a/cmd/gabi/exec/cmd.go
+++ b/cmd/gabi/exec/cmd.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"io/ioutil"
 	"os"
+	"regexp"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -12,6 +13,9 @@ import (
 	"github.com/cristianoveiga/gabi-cli/pkg/config"
 	"github.com/cristianoveiga/gabi-cli/pkg/history"
 )
+
+// twoMoreWhiteSpacesRegex holds the regular expression to match two or more subsequent white spaces.
+var twoMoreWhiteSpacesRegex *regexp.Regexp
 
 // Cmd represents the execute command
 var Cmd = &cobra.Command{
@@ -49,6 +53,9 @@ func init() {
 		false,
 		"Prints out the number of rows returned by your query",
 	)
+
+	// Compile the regex that matches two or more subsequent white spaces.
+	twoMoreWhiteSpacesRegex = regexp.MustCompile(`\s{2,}`)
 }
 
 func run(cmd *cobra.Command, argv []string) {
@@ -86,6 +93,7 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 
 	query = formatQuery(query)
+	log.Debugf("Formated query: %s", query)
 
 	// todo: define output types as enums
 	output := "json"
@@ -113,9 +121,18 @@ func run(cmd *cobra.Command, argv []string) {
 	}
 }
 
+// formatQuery replaces all the new lines, tab characters and the subsequent white spaces with a single white space,
+// and also removes the leading and trailing white spaces.
 func formatQuery(query string) string {
+	// Replace the new lines.
 	q := strings.ReplaceAll(query, "\n", " ")
+	// Replace the tab characters.
 	q = strings.ReplaceAll(q, "\t", " ")
+	// Replace two or more consecutive white spaces.
+	q = twoMoreWhiteSpacesRegex.ReplaceAllString(q, " ")
+	// Remove the leading and trailing white spaces.
+	q = strings.TrimSpace(q)
+
 	return q
 }
 


### PR DESCRIPTION
## Suggested changes

## Description of the first change
Adds the ability to read queries from a given path. When the "exec"
command is issued, the string is considered a path and a "stat" is
performed against that potential path.

If it happens to be a file, then we attempt to read the contents.
Otherwise it is assumed to be a regular query that the user passed.

## Description of the second change
The given queries may contain leading and trailing white spaces, as well
as many white spaces in between. The goal of this change is to remove them
from the given query.

It also marshals the query with the JSON marshaller, so that any
specified double quotes in the query are escaped for us.