### PR TITLE
refactor: only allow ".sql" files to be read

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Executes queries using the gabi-cli.
 `gabi exec -h`
 
 ```
-Executes a gabi query received from a string as argument, from a file path which gets read or from stdin. When using stdin, press Enter to move to the next line and then CTRL+D to execute the query (or CTRL+C to Cancel)
+Executes a gabi query received from a string as argument, from the file contents specified by a file path with an ".sql" extension, or from stdin. When using stdin, press Enter to move to the next line and then CTRL+D to execute the query (or CTRL+C to Cancel)
 
 Usage:
-  gabi execute [string] | [file_path] | stdin [flags]
+  gabi execute [string] | [sql_file_path] | stdin  [flags]
 
 Aliases:
   execute, exec

--- a/cmd/gabi/exec/cmd.go
+++ b/cmd/gabi/exec/cmd.go
@@ -3,6 +3,7 @@ package exec
 import (
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -19,9 +20,9 @@ var twoMoreWhiteSpacesRegex *regexp.Regexp
 
 // Cmd represents the execute command
 var Cmd = &cobra.Command{
-	Use:     "execute [string] | [file_path] | stdin",
+	Use:     "execute [string] | [sql_file_path] | stdin ",
 	Short:   "Executes a gabi query",
-	Long:    "Executes a gabi query received from a string as argument, from a file path which gets read or from stdin. When using stdin, press Enter to move to the next line and then CTRL+D to execute the query (or CTRL+C to Cancel)",
+	Long:    `Executes a gabi query received from a string as argument, from the file contents specified by a file path with an ".sql" extension, or from stdin. When using stdin, press Enter to move to the next line and then CTRL+D to execute the query (or CTRL+C to Cancel)`,
 	Run:     run,
 	Aliases: []string{"exec"},
 }
@@ -72,6 +73,10 @@ func run(cmd *cobra.Command, argv []string) {
 	if len(argv) > 0 {
 		// If the given arguments is a path, attempt reading the file. Otherwise, assume a query string was given.
 		if _, fileExistsErr := os.Stat(argv[0]); fileExistsErr == nil {
+			if filepath.Ext(argv[0]) != ".sql" {
+				logErrAndExit(`the specified file must have an ".sql" extension`)
+			}
+
 			body, readFileErr := ioutil.ReadFile(argv[0])
 			if readFileErr != nil {
 				logErrAndExit(readFileErr.Error())


### PR DESCRIPTION
Prior to this change, if an invalid file path was given to the "exec" command, the given path was interpreted as the query to be run with Gabi, which resulted in the database returning errors since it didn't understand the statement.

In order to avoid that, we are restricting the files we read to those which only end with an ".sql" extension. That way, we ensure that we give feedback to the user about the invalid specified file, and we avoid sending a bogus query to the Gabi instances.