### PR TITLE
client/query: Improve the error message on expired instances

### DIFF
--- a/pkg/client/query.go
+++ b/pkg/client/query.go
@@ -70,6 +70,11 @@ func (s QueryService) Query(q string, output string, showRowCount bool) error {
 		return errors.New(string(body))
 	}
 
+	if strings.Contains(string(body), "The service instance has expired") {
+		return errors.New(strings.TrimSpace(string(body)) +
+			" -- Please extend the `expirationDate` in the deployment config.")
+	}
+
 	dic := map[string]interface{}{}
 	if err = json.Unmarshal(body, &dic); err != nil {
 		return err


### PR DESCRIPTION
Improve the error message on expired instances

before:
```
ERRO[0000] invalid character 'T' looking for beginning of value
```

after:
```
ERRO[0000] The service instance has expired -- Please extend the `expirationDate` in the deployment config.
```
