### PR TITLE
fix: trim trailing slashes from URLs

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -2,6 +2,7 @@ package gabi
 
 import (
 	"net/http"
+	"strings"
 
 	"github.com/cristianoveiga/gabi-cli/pkg/config"
 )
@@ -15,7 +16,7 @@ type Client struct {
 func NewClient(profile config.Profile) (*Client, error) {
 	c := Client{
 		httpClient: &http.Client{},
-		baseURL:    profile.URL,
+		baseURL:    strings.TrimSuffix(profile.URL, "/"),
 		Token:      profile.Token,
 	}
 	return &c, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -141,7 +141,7 @@ func SetURL(url string) error {
 
 	for _, profile := range allProfiles {
 		if profile.Current {
-			profile.URL = url
+			profile.URL = strings.TrimSuffix(url, "/")
 			break
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 


### PR DESCRIPTION
Remove trailing slashes from client URLs. Otherwise, an unhelpful error message is thrown:
`ERRO[0000] unexpected end of JSON input`
since the utility tries to send a request to a URL that doesn't exist.